### PR TITLE
Prevent Swipe from triggering on vertical drag

### DIFF
--- a/Source/Touch/Swipe.js
+++ b/Source/Touch/Swipe.js
@@ -45,7 +45,7 @@ var events = {
 		
 		var touch = event.changedTouches[0];
 		var end = {x: touch.pageX, y: touch.pageY};
-		if (this.retrieve(cancelKey) && Math.abs(start.y - end.y) > Math.abs(start.x - end.x)){
+		if (this.retrieve(cancelKey) && Math.abs(start.y - end.y) > Math.abs(start.x - end.x) || Math.abs(start.y - end.y) > 50){
 			active = false;
 			return;
 		}


### PR DESCRIPTION
I made a small change to prevent the swipe event from triggering when dragging and item vertically. 

I've been using the iScroll library to enable vertical scrolling on list elements in my project. The problem occurs when a list item has a swipe event attached to it. Dragging the list vertically causes the swipe event to trigger because vertical dragging usually involves slight left/right motion. By limiting the vertical distance of a swipe to 50 pixels the issue no longer occurs. 
