### PR TITLE
Fix for HP TouchPad Browser.isMobile

### DIFF
--- a/Source/Browser/Mobile.js
+++ b/Source/Browser/Mobile.js
@@ -24,7 +24,7 @@ Browser.Device = {
 
 if (Browser.Platform.ios){
 	var device = navigator.userAgent.toLowerCase().match(/(ip(ad|od|hone))/)[0];
-	
+
 	Browser.Device[device] = true;
 	Browser.Device.name = device;
 }
@@ -32,6 +32,6 @@ if (Browser.Platform.ios){
 if (this.devicePixelRatio == 2)
 	Browser.hasHighResolution = true;
 
-Browser.isMobile = !['mac', 'linux', 'win'].contains(Browser.Platform.name);
+Browser.isMobile = !['mac', 'linux', 'win'].contains(Browser.Platform.name) || navigator.userAgent.contains('hp-tablet');
 
 }).call(this);


### PR DESCRIPTION
Hi cpojer,

i include the HP TouchPad identification the Browser.isMobile attribute.
Because the Browser.Platform.name is linux. Now I check on 'hp-tablet'' in the UA

i think hp-tablet is better then hpwOS 
... i'm not sure, but it can be, that the webOS runs on desktop, too.
so hp-tablet is something unique.

best regards
