### PR TITLE
Return Objects instead of string values for Swipe and Pinch

### DIFF
--- a/Demos/swipe.html
+++ b/Demos/swipe.html
@@ -21,7 +21,7 @@
 			element.store('swipe:cancelVertical', true);
 			element.addEvent('swipe', function(event){
 				this.set('text', 'Swipe ' + event.direction);
-
+				
 				clearTimeout(timer);
 				timer = (function(){
 					this.set('text', 'Swipe');

--- a/Source/Touch/Pinch.js
+++ b/Source/Touch/Pinch.js
@@ -38,6 +38,13 @@ var events = {
 
 		active = false;
 		event.pinch = (event.scale > 1) ? 'in' : 'out';
+		event.direction = {};
+		event.direction.in = event.pinch == 'in';
+		event.direction.out = event.pinch == 'out';
+		event.direction.toString = function() {
+			return	event.pinch;
+		}
+		
 		this.fireEvent(name, event);
 	}
 

--- a/Source/Touch/Swipe.js
+++ b/Source/Touch/Swipe.js
@@ -59,7 +59,14 @@ var events = {
 		
 		event.preventDefault();
 		active = false;
-		event.direction = (isLeftSwipe ? 'left' : 'right');
+		// event.direction = (isLeftSwipe ? 'left' : 'right');
+		event.direction = {};
+		event.direction.left = isLeftSwipe;
+		event.direction.right = isRightSwipe;
+		event.direction.toString = function() {
+			var side = (isLeftSwipe ? 'left' : 'right');
+			return	side;
+		}
 		event.start = start;
 		event.end = end;
 		


### PR DESCRIPTION
...th left,right and in, out boolean values, respectively.

For Swipe.js
event.direction.left and event.direction.right are boolean values
For Pinch.js
event.direction.in and event.direction.out are boolean values.
I find this way more comfortable than comparing to strings.
