### PR TITLE
Use of Browser.platform in Mootools 1.5.0

### DIFF
--- a/Source/Browser/Mobile.js
+++ b/Source/Browser/Mobile.js
@@ -22,7 +22,7 @@ Browser.Device = {
 	name: 'other'
 };
 
-if (Browser.ios){
+if (Browser.platform == "ios"){
 	var device = navigator.userAgent.toLowerCase().match(/(ip(ad|od|hone))/)[0];
 	
 	Browser.Device[device] = true;
@@ -32,6 +32,6 @@ if (Browser.ios){
 if (this.devicePixelRatio == 2)
 	Browser.hasHighResolution = true;
 
-Browser.isMobile = !['mac', 'linux', 'win'].contains(Browser.name);
+Browser.isMobile = !['mac', 'linux', 'windows'].contains(Browser.platform);
 
 }).call(this);


### PR DESCRIPTION
Reading further into the deprecated Browser.Platform, and looking inside Mootools 1.5.0 code, shows the Browser class now returns 'mac', 'linux', 'windows', 'ios', 'webos', 'android' or 'other'  when calling Browser.platform:

```
    var platform = ua.match(/ip(?:ad|od|hone)/) ? 'ios' : (ua.match(/(?:webos|android)/) || platform.match(/mac|win|linux/) || ['other'])[0];
    if (platform == 'win') platform = 'windows';
```

I tested in linux and ipad, and it works, pending Windows and Mac.
